### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM debian
+FROM debian:stretch-20200327
 
 # packages
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y \
     apache2 \
-    php php-gd php-xml \
+    libapache2-mod-php7.0 \
+    php php-gd php7.0-xml php-curl \
     python-pip python3-pip \
     cron \
     curl \
@@ -13,6 +14,8 @@ RUN apt-get install -y \
     mosquitto-clients \
     nano \
     socat \
+    sudo \
+    bc \
     supervisor
 
 # fix invoke-rc.d: policy-rc.d denied execution of start


### PR DESCRIPTION
Works with openwb 1.6 Stable. With debian:latest php7.0 will not work. php7.0 is mandatory for the graph to be shown. Info from snaptec. 

Maybe it is possible to split the branch in 1.6 stable and 1.7 stable? 1.7 Stable doesn't work for me, 1.6 does with the adjustments above. Sorry If i made something wrong here on github, I'm no "programmer guy" :-) Greets from bavaria. 